### PR TITLE
Fixing bug causing empty manifest in result jar

### DIFF
--- a/Tvl.Java.BuildTasks/Jar.cs
+++ b/Tvl.Java.BuildTasks/Jar.cs
@@ -125,7 +125,7 @@
                 if (!CreateManifest)
                     flags += 'M';
 
-                if (Manifest != null && Manifest.Length == 0 && Manifest[0].ItemSpec != null)
+                if (Manifest != null && Manifest.Length != 0 && Manifest[0].ItemSpec != null)
                     flags += 'm';
             }
 
@@ -136,7 +136,7 @@
 
             if (command == JarCommand.Create || command == JarCommand.Update)
             {
-                if (Manifest != null && Manifest.Length == 0 && Manifest[0].ItemSpec != null)
+                if (Manifest != null && Manifest.Length != 0 && Manifest[0].ItemSpec != null)
                     commandLine.AppendFileNameIfNotNull(Manifest[0]);
             }
 


### PR DESCRIPTION
Manifest file is not being included to jar file even when declared item <PackageManifest Include="$(ProjectDir)manifest.mf" />